### PR TITLE
feat(helm): Implement helm chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ __pycache__/
 *$py.class
 
 # Helm secrets files
-helm/values-secrets.yaml
+helm/agent-argocd/values-secrets.yaml
 helm/*/values-secrets.yaml
 
 # C extensions

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# Helm secrets files
+helm/values-secrets.yaml
+helm/*/values-secrets.yaml
+
 # C extensions
 *.so
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,236 @@
+# ArgoCD Agent Helm Chart
+
+This Helm chart deploys the ArgoCD Agent powered by LangGraph and LangChain MCP Adapters on Kubernetes.
+
+## Prerequisites
+
+- [Minikube](https://minikube.sigs.k8s.io/docs/start/) installed
+- [Helm](https://helm.sh/docs/intro/install/) installed
+- [kubectl](https://kubernetes.io/docs/tasks/tools/) installed
+
+## Getting Started
+
+### Step 1: Start Minikube
+
+```bash
+minikube start
+```
+
+Verify minikube is running:
+```bash
+minikube status
+kubectl get nodes
+```
+
+### Step 2: Configure Secrets
+
+Create a `values-secrets.yaml` file with your API keys and configuration. You can use the provided example as a template:
+
+```bash
+# Copy the example file
+cp values-secrets.yaml.example values-secrets.yaml
+
+# Edit with your actual values
+vim values-secrets.yaml
+```
+
+Example `values-secrets.yaml` structure:
+
+```yaml
+# Values file with secrets for agent-argocd
+# WARNING: This file contains sensitive information - do not commit to version control
+
+secrets:
+  llmProvider: "azure-openai"  # Options: azure-openai, openai, anthropic-claude
+  
+  # Azure OpenAI Configuration (if using Azure OpenAI)
+  azureOpenaiApiKey: "your-azure-openai-api-key"
+  azureOpenaiEndpoint: "https://your-resource.openai.azure.com/"
+  azureOpenaiApiVersion: "2023-12-01-preview"
+  azureOpenaiDeployment: "gpt-4"
+  
+  # OpenAI Configuration (if using OpenAI)
+  # openaiApiKey: "your-openai-api-key"
+  # openaiEndpoint: "https://api.openai.com/v1"
+  # openaiModelName: "gpt-4"
+  
+  # Anthropic Configuration (if using Anthropic)
+  # anthropicApiKey: "your-anthropic-api-key"
+  # anthropicModelName: "claude-3-5-sonnet-20241022"
+  
+  # AWS/Bedrock Configuration (if using AWS Bedrock)
+  # awsProfile: "default"
+  # awsRegion: "us-east-1"
+  # awsBedrockModelId: "anthropic.claude-3-sonnet-20240229-v1:0"
+  # awsBedrockProvider: "anthropic"
+  
+  # Google/Vertex AI Configuration (if using Google)
+  # googleApiKey: "your-google-api-key"
+  # googleApplicationCredentials: "/path/to/service-account.json"
+  # vertexaiModelName: "gemini-pro"
+  
+  # ArgoCD Configuration (Required)
+  argocdToken: "your-argocd-jwt-token"
+  argocdApiUrl: "https://your-argocd-instance.com"
+  argocdVerifySsl: "true"
+
+# Non-sensitive environment variables
+env: {}
+```
+
+**⚠️ Important**: Never commit `values-secrets.yaml` to version control! It's already in `.gitignore`.
+
+## Deployment Options
+
+### Option 1: Simple Deployment (Port-Forward Access)
+
+This is the simplest way to deploy and access your ArgoCD agent.
+
+#### Deploy the Chart
+
+```bash
+# Ensure you're inside the chart dir
+cd helm/agent-argocd
+helm install agent-argocd . --values values-secrets.yaml
+```
+
+#### Check Deployment Status
+
+```bash
+kubectl get pods
+kubectl get services
+```
+
+Wait for the pod to be in `Running` state and `1/1` ready.
+
+#### Access the Application
+
+Set up port forwarding:
+```bash
+kubectl port-forward service/agent-argocd 8080:8000
+```
+
+Your ArgoCD agent will be available at: `http://localhost:8080`
+
+#### Using with Agent Chat CLI
+
+```bash
+# Install and use the agent chat CLI
+uvx https://github.com/cnoe-io/agent-chat-cli.git a2a --host localhost --port 8080
+```
+
+---
+
+### Option 2: Ingress Deployment (Domain Access)
+
+This option sets up ingress for cleaner access via a domain name.
+
+#### Enable Minikube Ingress
+
+```bash
+minikube addons enable ingress
+```
+
+Wait for the ingress controller to be ready:
+```bash
+kubectl wait --namespace ingress-nginx \
+  --for=condition=ready pod \
+  --selector=app.kubernetes.io/component=controller \
+  --timeout=300s
+```
+
+#### Create Ingress Values File
+
+Enable ingress in `values.yaml`:
+
+```yaml
+ingress:
+  enabled: true
+```
+
+#### Deploy with Ingress
+
+```bash
+# Ensure you're inside the chart dir
+cd helm/agent-argocd
+helm install agent-argocd . --values values-secrets.yaml
+```
+
+Or upgrade if already deployed:
+```bash
+helm upgrade agent-argocd . --values values-secrets.yaml
+```
+
+#### Configure Local DNS
+
+Add the minikube IP to your `/etc/hosts` file:
+
+```bash
+# Get minikube IP
+minikube ip
+
+# Add to /etc/hosts (replace with your minikube IP)
+echo "$(minikube ip) agent-argocd.local" | sudo tee -a /etc/hosts
+```
+
+#### Verify Ingress
+
+```bash
+kubectl get ingress
+curl -i http://agent-argocd.local
+```
+
+You should see a `405 Method Not Allowed` response, which is expected (the agent only accepts POST requests).
+
+#### Using with Agent Chat CLI
+
+```bash
+# Use the domain name instead of localhost
+uvx https://github.com/cnoe-io/agent-chat-cli.git a2a --host agent-argocd.local --port 80
+```
+
+## Management Commands
+
+### View Logs
+```bash
+kubectl logs -l app.kubernetes.io/name=agent-argocd
+```
+
+### Check Pod Status
+```bash
+kubectl get pods -l app.kubernetes.io/name=agent-argocd
+```
+
+### Update Secrets
+1. Edit your `values-secrets.yaml` file
+2. Upgrade the deployment:
+   ```bash
+   helm upgrade agent-argocd ./agent-argocd --values values-secrets.yaml
+   ```
+
+### Uninstall
+```bash
+helm uninstall agent-argocd
+```
+
+### Clean up /etc/hosts (if using ingress)
+```bash
+sudo sed -i '/agent-argocd.local/d' /etc/hosts
+```
+
+## Configuration
+
+### Required Environment Variables
+- `ARGOCD_TOKEN`: ArgoCD JWT token for API access
+- `ARGOCD_API_URL`: ArgoCD API endpoint
+- `ARGOCD_VERIFY_SSL`: SSL verification setting
+- `LLM_PROVIDER`: The LLM provider to use
+- Provider-specific API keys and configuration (see examples in `values-secrets.yaml.example`)
+
+## Security Notes
+
+- Always use Kubernetes secrets for sensitive data
+- Never commit `values-secrets.yaml` to version control
+- Rotate API keys regularly
+- Use HTTPS in production environments
+- Consider using external secret management solutions for production

--- a/helm/agent-argocd/templates/deployment.yaml
+++ b/helm/agent-argocd/templates/deployment.yaml
@@ -44,6 +44,16 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+          envFrom:
+            - secretRef:
+                name: {{ .Values.secrets.secretName | default (printf "%s-secret" (include "agent-argocd.fullname" .)) }}
+          {{- if .Values.env }}
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/helm/agent-argocd/templates/secret.yaml
+++ b/helm/agent-argocd/templates/secret.yaml
@@ -1,0 +1,73 @@
+{{- if not .Values.secrets.secretName }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "agent-argocd.fullname" . }}-secret
+  labels:
+    {{- include "agent-argocd.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if .Values.secrets.llmProvider }}
+  LLM_PROVIDER: {{ .Values.secrets.llmProvider | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.openaiApiKey }}
+  OPENAI_API_KEY: {{ .Values.secrets.openaiApiKey | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.azureOpenaiApiKey }}
+  AZURE_OPENAI_API_KEY: {{ .Values.secrets.azureOpenaiApiKey | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.azureOpenaiEndpoint }}
+  AZURE_OPENAI_ENDPOINT: {{ .Values.secrets.azureOpenaiEndpoint | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.azureOpenaiApiVersion }}
+  AZURE_OPENAI_API_VERSION: {{ .Values.secrets.azureOpenaiApiVersion | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.azureOpenaiDeployment }}
+  AZURE_OPENAI_DEPLOYMENT: {{ .Values.secrets.azureOpenaiDeployment | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.anthropicApiKey }}
+  ANTHROPIC_API_KEY: {{ .Values.secrets.anthropicApiKey | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.anthropicModelName }}
+  ANTHROPIC_MODEL_NAME: {{ .Values.secrets.anthropicModelName | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.openaiEndpoint }}
+  OPENAI_ENDPOINT: {{ .Values.secrets.openaiEndpoint | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.openaiModelName }}
+  OPENAI_MODEL_NAME: {{ .Values.secrets.openaiModelName | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.awsProfile }}
+  AWS_PROFILE: {{ .Values.secrets.awsProfile | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.awsRegion }}
+  AWS_REGION: {{ .Values.secrets.awsRegion | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.awsBedrockModelId }}
+  AWS_BEDROCK_MODEL_ID: {{ .Values.secrets.awsBedrockModelId | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.awsBedrockProvider }}
+  AWS_BEDROCK_PROVIDER: {{ .Values.secrets.awsBedrockProvider | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.googleApiKey }}
+  GOOGLE_API_KEY: {{ .Values.secrets.googleApiKey | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.googleApplicationCredentials }}
+  GOOGLE_APPLICATION_CREDENTIALS: {{ .Values.secrets.googleApplicationCredentials | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.vertexaiModelName }}
+  VERTEXAI_MODEL_NAME: {{ .Values.secrets.vertexaiModelName | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.argocdToken }}
+  ARGOCD_TOKEN: {{ .Values.secrets.argocdToken | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.argocdApiUrl }}
+  ARGOCD_API_URL: {{ .Values.secrets.argocdApiUrl | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.argocdVerifySsl }}
+  ARGOCD_VERIFY_SSL: {{ .Values.secrets.argocdVerifySsl | b64enc | quote }}
+  {{- end }}
+  {{- range $key, $value := .Values.secrets.additionalSecrets }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/helm/agent-argocd/values.yaml
+++ b/helm/agent-argocd/values.yaml
@@ -87,13 +87,19 @@ resources: {}
 
 # This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 livenessProbe:
-  httpGet:
-    path: /
+  tcpSocket:
     port: http
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
 readinessProbe:
-  httpGet:
-    path: /
+  tcpSocket:
     port: http
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 3
 
 # This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:
@@ -121,3 +127,41 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Secrets configuration for LLM providers
+secrets:
+  # if set, use this secret for the LLM provider API keys; if not set, the keys will be provided directly below
+  secretName: ""
+  # below are the API keys for the LLM providers; if secretName is set, these will be ignored
+  # LLM Provider: azure-openai, openai, anthropic-claude
+  llmProvider: ""
+  # OpenAI configuration
+  openaiApiKey: ""
+  # Azure OpenAI configuration
+  azureOpenaiApiKey: ""
+  azureOpenaiEndpoint: ""
+  azureOpenAiApiVersion: ""
+  azureOpenAiDeployment: ""
+  # Anthropic configuration
+  anthropicApiKey: ""
+  anthropicModelName: ""
+  # OpenAI configuration
+  openaiApiKey: ""
+  openaiEndpoint: ""
+  openaiModelName: ""
+  # AWS/Bedrock configuration
+  awsProfile: ""
+  awsRegion: ""
+  awsBedrockModelId: ""
+  awsBedrockProvider: ""
+  # Google/Vertex AI configuration
+  googleApiKey: ""
+  googleApplicationCredentials: ""
+  vertexaiModelName: ""
+  # ArgoCD configuration
+  argocdToken: ""
+  argocdApiUrl: ""
+  argocdVerifySsl: ""
+
+# Environment variables (non-sensitive)
+env: {}

--- a/helm/agent-argocd/values.yaml
+++ b/helm/agent-argocd/values.yaml
@@ -59,19 +59,19 @@ service:
 # This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ingress:
   enabled: false
-  className: ""
+  className: "nginx"
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
-    - host: chart-example.local
+    - host: agent-argocd.local
       paths:
         - path: /
-          pathType: ImplementationSpecific
+          pathType: Prefix
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
-  #      - chart-example.local
+  #      - agent-argocd.local
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/helm/values-secrets.yaml.example
+++ b/helm/values-secrets.yaml.example
@@ -1,0 +1,43 @@
+# Example values-secrets.yaml for agent-argocd
+# WARNING: This file contains sensitive information - do not commit to version control
+# Copy this file and fill in your actual values
+
+secrets:
+  # LLM Provider - Choose one: azure-openai, openai, anthropic-claude
+  llmProvider: "azure-openai"
+  
+  # OpenAI Configuration (uncomment and fill if using OpenAI)
+  # openaiApiKey: "sk-your-openai-api-key-here"
+  # openaiEndpoint: "https://api.openai.com/v1"
+  # openaiModelName: "gpt-4"
+  
+  # Azure OpenAI Configuration (uncomment and fill if using Azure OpenAI)
+  azureOpenaiApiKey: "your-azure-openai-api-key"
+  azureOpenaiEndpoint: "https://your-resource.openai.azure.com/"
+  azureOpenaiApiVersion: "2025-03-01-preview"
+  azureOpenaiDeployment: "gpt-4"
+  
+  # Anthropic Configuration (uncomment and fill if using Anthropic)
+  # anthropicApiKey: "sk-ant-your-anthropic-api-key"
+  # anthropicModelName: "claude-3-5-sonnet-20241022"
+  
+  # AWS/Bedrock Configuration (uncomment and fill if using AWS Bedrock)
+  # awsProfile: "default"
+  # awsRegion: "us-east-1"
+  # awsBedrockModelId: "anthropic.claude-3-sonnet-20240229-v1:0"
+  # awsBedrockProvider: "anthropic"
+  
+  # Google/Vertex AI Configuration (uncomment and fill if using Google)
+  # googleApiKey: "your-google-api-key"
+  # googleApplicationCredentials: "/path/to/service-account.json"
+  # vertexaiModelName: "gemini-pro"
+  
+  # ArgoCD Configuration (Required - replace with your actual values)
+  argocdToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.your-actual-jwt-token"
+  argocdApiUrl: "https://your-argocd-instance.com"
+  argocdVerifySsl: "true"
+
+# Non-sensitive environment variables (optional)
+env:
+  # LOG_LEVEL: "info"
+  # DEBUG: "false"


### PR DESCRIPTION
# Description

- Fix the existing helm chart folder to work
  - create secret resource to store all env variables required
  - readiness probe and nginx fix
  - added a README file on how to run with minikube

Currently the below implementation has only been tested on minikube, but people should be able to easily modify this to use their existing nginx and external dns to fully deploy the service, as well as use external secrets for a better secret management.


## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
